### PR TITLE
Require Ruby 2.2 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - ree
-  - 1.9.3
-  - 2.0.0
-  - 2.1.9
   - 2.2.5
   - 2.3.1
   - ruby-head

--- a/domain_name.gemspec
+++ b/domain_name.gemspec
@@ -19,8 +19,7 @@ Suffix List.
   gem.licenses      = ["BSD-2-Clause", "BSD-3-Clause", "MPL-2.0"]
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.test_files    = gem.files.grep(%r{^test/})
   gem.require_paths = ["lib"]
 
   gem.extra_rdoc_files = [
@@ -28,7 +27,8 @@ Suffix List.
     "README.md"
   ]
 
-  gem.add_runtime_dependency("unf", ["< 1.0.0", ">= 0.0.5"])
+  gem.required_ruby_version = ">= 2.2"
+
   gem.add_development_dependency("test-unit", "~> 2.5.5")
   gem.add_development_dependency("bundler", [">= 1.2.0"])
   gem.add_development_dependency("rake", [">= 0.9.2.2", *("< 11" if RUBY_VERSION < "1.9")])

--- a/lib/domain_name.rb
+++ b/lib/domain_name.rb
@@ -8,7 +8,7 @@
 require 'domain_name/version'
 require 'domain_name/punycode'
 require 'domain_name/etld_data'
-require 'unf'
+require 'unicode_normalize/normalize'
 require 'ipaddr'
 
 # Represents a domain name ready for extracting its registered domain
@@ -286,7 +286,7 @@ class DomainName
     # Normalizes a _domain_ using the Punycode algorithm as necessary.
     # The result will be a downcased, ASCII-only string.
     def normalize(domain)
-      DomainName::Punycode.encode_hostname(domain.chomp(DOT).to_nfc).downcase
+      DomainName::Punycode.encode_hostname(domain.chomp(DOT).unicode_normalize).downcase
     end
   end
 end

--- a/test/test_domain_name-punycode.rb
+++ b/test/test_domain_name-punycode.rb
@@ -91,7 +91,7 @@ class TestDomainName < Test::Unit::TestCase
         '-> $1.00 <--']
     ].each { |title, cps, punycode|
       assert_equal punycode, DomainName::Punycode.encode(cps.pack('U*')), title
-      assert_equal cps.pack('U*').to_nfc, DomainName::Punycode.decode(punycode), title
+      assert_equal cps.pack('U*').unicode_normalize, DomainName::Punycode.decode(punycode), title
     }
   end
 end


### PR DESCRIPTION
Remove support for EOL Ruby releases and remove the unf gem that is no
longer required by doing so. This greatly reduces memory usage.

This just pulls in the ruby 2.2+ support in https://github.com/knu/ruby-domain_name/pull/11, but removes support for the older ruby releases so the gemspec will work.

Signed-off-by: Tim Smith <tsmith@chef.io>