### PR TITLE
Fix regression: Allow DomainName.normalize to accept ASCII-only, non-unicode encoded input

### DIFF
--- a/lib/domain_name.rb
+++ b/lib/domain_name.rb
@@ -283,9 +283,13 @@ class DomainName
 
   class << self
     # Normalizes a _domain_ using the Punycode algorithm as necessary.
+    # Input must be strictly ASCII-only or unicode.
     # The result will be a downcased, ASCII-only string.
     def normalize(domain)
-      DomainName::Punycode.encode_hostname(domain.chomp(DOT).unicode_normalize(:nfc)).downcase
+      chomped = domain.chomp(DOT)
+      normalized = chomped.ascii_only? ? chomped : chomped.unicode_normalize(:nfc)
+
+      DomainName::Punycode.encode_hostname(normalized).downcase
     end
   end
 end

--- a/test/test_domain_name.rb
+++ b/test/test_domain_name.rb
@@ -35,6 +35,10 @@ class TestDomainName < Test::Unit::TestCase
     }
   end
 
+  test "accept ASCII-only 'binary' encoded hostnames" do
+    assert_equal "example.com", DomainName.new("example.com".force_encoding("ASCII-8BIT")).hostname
+  end
+
   test "parse canonical domain names correctly" do
     [
       # Mixed case.


### PR DESCRIPTION
Fixes https://github.com/knu/ruby-domain_name/issues/23

Until `v0.5.20190701` `unf` was used for unicode normalization, see https://github.com/knu/ruby-domain_name/blob/v0.5.20190701/lib/domain_name.rb?rgh-link-date=2023-12-26T17%3A13%3A41Z#L285-L291. But `unf` returns `self` for `String#to_nfc` if `self` is strictly ASCII-only (see https://github.com/knu/ruby-unf/blob/v0.1.4/lib/unf.rb). In the current gem version, unicode normalization is always performed, resulting in a breaking change if a non-unicode encoded string is provided to `.normalize` (or the initializer which calls normalize).

This PR attempts to restore the original behaviour, which would allow other encodings to skip normalization, if they are strictly ASCII-only (by definition no unicode normalization is possible anyway in this case). This is done via [`String#ascii_only?`](https://ruby-doc.org/3.2.2/String.html#method-i-ascii_only-3F).