### PR TITLE
adding CHANGELOG.md to gemspec, so Rubygems.org finds the change log.

### DIFF
--- a/domain_name.gemspec
+++ b/domain_name.gemspec
@@ -19,6 +19,10 @@ Suffix List.
   gem.homepage      = "https://github.com/knu/ruby-domain_name"
   gem.licenses      = ["BSD-2-Clause", "BSD-3-Clause", "MPL-2.0"]
 
+  gem.metadata["homepage_uri"] = gem.homepage
+  gem.metadata["source_code_uri"] = gem.homepage
+  gem.metadata["changelog_uri"] = "https://github.com/knu/ruby-domain_name/blob/master/CHANGELOG.md"
+
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Currently Rubygems.org and Rubytoolbox.com don't have a way to find the CHANGELOG.md file.
(see picture)

![Screenshot 2024-07-31 at 10 51 12](https://github.com/user-attachments/assets/e405ff9b-fde4-457a-9c30-b03df93d5a7e)


This PR adds `gem.metadata` to the .gemspec file, and makes the CHANGELOG discoverable.
After merging it will look like this:

![Screenshot 2024-07-31 at 10 52 27](https://github.com/user-attachments/assets/8e4ecb34-b48e-4dc4-9c76-2389b43a0fce)
